### PR TITLE
fix: correct typo in nonroad flow name (rough terrain forklifts)

### DIFF
--- a/data/moves_nonroad_flows.csv
+++ b/data/moves_nonroad_flows.csv
@@ -163,7 +163,7 @@ Construction,2270002045,Dsl - Cranes,cranes,23: Construction / 2382: Building Eq
 Construction,2270002048,Dsl - Graders,graders,23: Construction / 2382: Building Equipment Contractors,23: Construction / 2382: Building Equipment Contractors
 Construction,2270002051,Dsl - Off-highway Trucks,,,
 Construction,2270002054,Dsl - Crushing/Proc. Equipment,crushing and processing equipment,23: Construction / 2382: Building Equipment Contractors,23: Construction / 2382: Building Equipment Contractors
-Construction,2270002057,Dsl - Rough Terrain Forklifts,rough terrian folklifts,23: Construction / 2382: Building Equipment Contractors,23: Construction / 2382: Building Equipment Contractors
+Construction,2270002057,Dsl - Rough Terrain Forklifts,rough terrain forklifts,23: Construction / 2382: Building Equipment Contractors,23: Construction / 2382: Building Equipment Contractors
 Construction,2270002060,Dsl - Rubber Tire Loaders,rubber tire loaders,23: Construction / 2382: Building Equipment Contractors,23: Construction / 2382: Building Equipment Contractors
 Construction,2270002066,Dsl - Tractors/Loaders/Backhoes,tractors/loaders/backhoes,23: Construction / 2382: Building Equipment Contractors,23: Construction / 2382: Building Equipment Contractors
 Construction,2270002069,Dsl - Crawler Tractor/Dozers,crawler tractor/dozers,23: Construction / 2382: Building Equipment Contractors,23: Construction / 2382: Building Equipment Contractors


### PR DESCRIPTION
Fixes FLCAC-admin/uslci-moves#12

Corrects typo in data/moves_nonroad_flows.csv line 166:
- Before: `rough terrian folklifts`
- After: `rough terrain forklifts`

Simple 1-word fix: 'terrian' → 'terrain', 'folklifts' → 'forklifts'